### PR TITLE
Change the default package name of react-native libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ the native components of this library manually.
 ### Android
 
 1. Open up `android/app/src/main/java/[...]/MainApplication.java`
-  - Add `import com.reactlibrary.RNUUIDGeneratorPackage;` to the imports at the top of the file
+  - Add `import com.Traviskn.RNUUIDGeneratorPackage;` to the imports at the top of the file
   - Add `new RNUUIDGeneratorPackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:
   ```

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.Traviskn">
 
 </manifest>

--- a/android/src/main/java/com/Traviskn/RNUUIDGeneratorModule.java
+++ b/android/src/main/java/com/Traviskn/RNUUIDGeneratorModule.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.Traviskn;
 
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/src/main/java/com/Traviskn/RNUUIDGeneratorPackage.java
+++ b/android/src/main/java/com/Traviskn/RNUUIDGeneratorPackage.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.Traviskn;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/example/android/app/src/main/java/com/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/MainApplication.java
@@ -3,7 +3,7 @@ package com.example;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
-import com.reactlibrary.RNUUIDGeneratorPackage;
+import com.Traviskn.RNUUIDGeneratorPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;


### PR DESCRIPTION
Fix
Error:Execution failed for task ':app:processDebugResources'.
:More than one library with package name 'com.reactlibrary'
If we have another dependency that didn't change the default name.