### PR TITLE
Add pod support (make autolink work on iOS with react-native >= 0.60.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-native",
     "uuid"
   ],
+  "homepage": "https://github.com/Traviskn/react-native-uuid-generator#readme",
   "author": "Travis Nuttall",
   "license": "MIT",
   "peerDependencies": {

--- a/react-native-uuid-generator.podspec
+++ b/react-native-uuid-generator.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "react-native-uuid-generator"
+  s.version      = package['version']
+  s.summary      = package['description']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.license      = package['license']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/Traviskn/react-native-uuid-generator.git", :tag => "#{s.version}" }
+  s.source_files  = "ios/*.{h,m}"
+
+  s.dependency 'React'
+end
+


### PR DESCRIPTION
Tested with react-native == 0.60.3

Make react-native-uuid-generator works on iOS with react-native >= 0.60 by simply using `pod install`