### PR TITLE
Fix RN 0.60+ installation by including podspec in package.json file list

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "files": [
     "android/",
     "ios/",
-    "index.js"
+    "index.js",
+    "react-native-uuid-generator.podspec"
   ]
 }


### PR DESCRIPTION
This is required so the podspec will be downloaded and found by CocoaPods when installing pods locally during installation.

Closes #21.

@Traviskn Could you have a look and make a new NPM release if everything looks okay? I tried it with my forked repo and it worked 👌 Thank you!