### PR TITLE
Load Android Gradle Plugin conditionally

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,21 @@
-buildscript {
-    ext.safeExtGet = {prop, fallback ->
-        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-    }
-    repositories {
-        jcenter()
-        google()
-    }
+def safeExtGet(prop, fallback) {
+	rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
-    dependencies {
-        classpath("com.android.tools.build:gradle:${safeExtGet('gradlePluginVersion', '3.4.1')}")
+buildscript {
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+
+        dependencies {
+            //noinspection GradleDependency
+            classpath("com.android.tools.build:gradle:3.5.3")
+        }
     }
 }
 
@@ -33,6 +40,6 @@ android {
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:${safeExtGet("reactNative", "+")}"
+    implementation "com.facebook.react:react-native:+"
 }
 


### PR DESCRIPTION
This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)