### PR TITLE
React -> React-Core for Xcode 12 compatibility

### DIFF
--- a/react-native-uuid-generator.podspec
+++ b/react-native-uuid-generator.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Traviskn/react-native-uuid-generator.git", :tag => "#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end
 


### PR DESCRIPTION
Hi there, following the discussions linked below, for Xcode 12 compatibility react native libraries should ideally depend on React-Core rather than the React umbrella dependency. Thanks so much.

https://github.com/facebook/react-native/issues/29633#issuecomment-694187116